### PR TITLE
errnilcheck: detect superfluous nil check before return

### DIFF
--- a/errnilcheck.yml
+++ b/errnilcheck.yml
@@ -1,0 +1,18 @@
+
+rules:
+  - id: err-nil-check
+    patterns:
+        - pattern-either:
+              - pattern: |
+                      if err != nil {
+                              return err
+                      }
+                      return nil
+              - pattern: |
+                      if err != nil {
+                              return $X, err
+                      }
+                      return $X, nil
+    message: "superfluous nil err check before return"
+    languages: [go]
+    severity: ERROR


### PR DESCRIPTION
This detects patterns such as

```go
func foo() error {
	...
	err := bar()
	if err != nil {
		return err
	}
	return nil
}
```

which could be simplified as


```go
func foo() error {
	...
	return bar()
}
```

I'm not sure whether this is a general pattern worthwhile having, but it's something I personally try to avoid and for which I've occasionally also sent fixes, e.g. https://github.com/golang/go/commit/4b94e881611890c6d6cbda6f542a94ab08de17e0