### PR TITLE
httpheaderadd: new ruleguard check for http.Header.Add

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Ruleguard checks are in ruleguard.rules.go.
 * readfull: check for extra length check for io.ReadFull()
 * nilerr: returning an nil error instead of a nil value
 * errnetclosed: check for call strings.Contains() to detect net.ErrClosed
+* httpheaderadd: check for use of http.Header.Add method instead of Set
 _
 
 *Find this useful? [Buy me a coffee!](https://www.buymeacoffee.com/dgryski)*

--- a/ruleguard.rules.go
+++ b/ruleguard.rules.go
@@ -423,8 +423,17 @@ func errnetclosed(m fluent.Matcher) {
 	m.Match(
 		`strings.Contains($err.Error(), $text)`,
 	).
-	Where(m["text"].Text.Matches("\".*closed network connection.*\"")).
+		Where(m["text"].Text.Matches("\".*closed network connection.*\"")).
 		Report(`String matching against error texts is fragile; use net.ErrClosed instead`).
 		Suggest(`errors.Is($err, net.ErrClosed)`)
 
+}
+
+func httpheaderadd(m fluent.Matcher) {
+	m.Match(
+		`$H.Add($KEY, $VALUE)`,
+	).
+		Where(m["H"].Type.Is("http.Header")).
+		Report("use http.Header.Set method instead of Add to overwrite all existing header values").
+		Suggest(`$H.Set($KEY, $VALUE)`)
 }


### PR DESCRIPTION
Given the program:

```go
package main

import (
	"net/http"
)

func main() {
	var h http.Header
	h.Add("Foo", "Bar")

	var r *http.Request
	r.Header.Add("Foo", "Bar")

	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
		w.Header().Add("Foo", "bar")
	})
}
```

This reports:

```
/home/matt/src/github.com/mdlayher/tmp/main.go:9:2: use http.Header.Set method instead of Add to overwrite all existing header values
/home/matt/src/github.com/mdlayher/tmp/main.go:12:2: use http.Header.Set method instead of Add to overwrite all existing header values
/home/matt/src/github.com/mdlayher/tmp/main.go:15:3: use http.Header.Set method instead of Add to overwrite all existing header values
```