### PR TITLE
explain why the LeadingZeros usage is considered odd

### DIFF
--- a/oddmathbits.yml
+++ b/oddmathbits.yml
@@ -6,6 +6,6 @@ rules:
               - pattern: 32 - bits.LeadingZeros32($X)
               - pattern: 16 - bits.LeadingZeros16($X)
               - pattern: 8 - bits.LeadingZeros8($X)
-    message: "Odd bits.LeadingZeros() expression"
+    message: "Odd bits.LeadingZeros() expression should perhaps be bits.Len()"
     languages: [go]
     severity: ERROR


### PR DESCRIPTION
As a person who was using this pattern, I wasn't aware of Len64() and friends, so I was unsure what to make of the message.