### PR TITLE
ruleguard: replace Report with Suggest in writestring

### DIFF
--- a/ruleguard.rules.go
+++ b/ruleguard.rules.go
@@ -463,5 +463,5 @@ func readeof(m fluent.Matcher) {
 func writestring(m fluent.Matcher) {
 	m.Match(`io.WriteString($w, string($b))`).
 		Where(m["b"].Type.Is("[]byte")).
-		Report("use $w.Write($b)")
+		Suggest("$w.Write($b)")
 }


### PR DESCRIPTION
We'll get "suggested: <text>" instead of "use <text>" when running
without autofixes, but if they're enabled, the code can be fixed automatically.

It's possible to keep `Report()` as well so we have a more human-readable
message, but in this case, it doesn't seem to add much context.