### PR TITLE
readme: ruleguard run all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ semgrep -f path/to/semgrep-go/ .
 To run all the ruleguard rules:
 
 ```
-$ ruleguard -c=0 -rules path/to/semgrep-go/rules.go
+$ ruleguard -c=0 -rules path/to/semgrep-go/ruleguard.rules.go .
 ```
 
 


### PR DESCRIPTION
This change assumes that most people will fork your repo and try to run ruleguard using
your `ruleguard.rules.go` file.