### PR TITLE
context.TODO()

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Ruleguard checks are in ruleguard.rules.go.
 * readeof: check for ignoring io.EOF as a successful read
 * writestring: check for using io.WriteString(w, string(b)) when b is []byte
 * badlock: find incorrect lock/unlock pairs for rwmutex
+* contexttodo: find context.TODO() usage and suggest to change it
 _
 
 *Find this useful? [Buy me a coffee!](https://www.buymeacoffee.com/dgryski)*

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Semgrep checks:
 * readeof: check for ignoring io.EOF as a successful read
 * writestring: check for using io.WriteString(w, string(b))
 * wronglock: find incorrect lock/unlock pairs for rwmutex
+* contexttodo: find context.TODO() usage and suggest to change it
 
 Ruleguard checks are in ruleguard.rules.go.
 * unconvert: check for unnecessary conversions

--- a/contextTODO.yml
+++ b/contextTODO.yml
@@ -1,0 +1,9 @@
+rules:
+  - id: context-todo
+    patterns:
+        - pattern-either:
+              - pattern: |
+                      context.TODO()
+    message: "Consider to use well-defined context"
+    languages: [go]
+    severity: WARNING

--- a/ruleguard.rules.go
+++ b/ruleguard.rules.go
@@ -477,3 +477,7 @@ func badlock(m fluent.Matcher) {
 	m.Match(`$mu.Lock(); defer $mu.RUnlock()`).Report(`maybe $mu.RLock() was intended?`)
 	m.Match(`$mu.RLock(); defer $mu.Unlock()`).Report(`maybe $mu.Lock() was intended?`)
 }
+
+func contextTODO(m fluent.Matcher) {
+	m.Match(`context.TODO()`).Report(`consider to use well-defined context`)
+}


### PR DESCRIPTION
```
// TODO returns a non-nil, empty Context. Code should use context.TODO when
// it's unclear which Context to use or it is not yet available (because the
// surrounding function has not yet been extended to accept a Context
// parameter). TODO is recognized by static analysis tools that determine
// whether Contexts are propagated correctly in a program.
func TODO() Context {
	return todo
}
```
But last sentence was removed from the documentation in https://go-review.googlesource.com/c/go/+/130876/

Also issues https://github.com/golang/lint/pull/227 & https://github.com/golang/go/issues/16742

Already added to `ruleguard` https://github.com/quasilyte/go-ruleguard/pull/119