### PR TITLE
io.Seek: Check argument order

### DIFF
--- a/seekargorder.yml
+++ b/seekargorder.yml
@@ -1,0 +1,10 @@
+rules:
+  - id: seek-arg-order
+    patterns:
+        - pattern-either:
+            - pattern: $VAR.Seek(io.SeekCurrent, $POS)
+            - pattern: $VAR.Seek(io.SeekStart, $POS)
+            - pattern: $VAR.Seek(io.SeekEnd, $POS)
+    message: "Incorrect io.Seek argument order."
+    languages: [go]
+    severity: ERROR


### PR DESCRIPTION
Since the io.Seek constants are just integers, you can accidentally call io.Seek with its arguments in the wrong order, and the Go compiler will not complain.