### PR TITLE
Add os.PathSeparator to use-strings-join-path

### DIFF
--- a/joinpath.yml
+++ b/joinpath.yml
@@ -5,6 +5,7 @@ rules:
                         - pattern: strings.Join(..., "/")
                         - pattern: strings.Join(..., "\\")
                         - pattern: strings.Join(..., `\`)
+                        - pattern: strings.Join(..., os.PathSeparator)
     message: "did you want path.Join() or filepath.Join()?"
     languages: [go]
     severity: ERROR


### PR DESCRIPTION
Though this should be technically correct, it still may be more clear to use filepath.Join()