### PR TITLE
adds semgrep rule on cancelable contex

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Semgrep checks:
 * close-sql-query-rows: find places database/sql.Rows instance isn't Close()d
 * unixnano: check for time.Time comparisons using UnixNano()
 * timeafter: leaky use of time.After()
+* contextCancelable: checks for cancelable contexts not systematically canceled
 
 Ruleguard checks are in ruleguard.rules.go.
 * unconvert: check for unnecessary conversions

--- a/contextCancelable.yml
+++ b/contextCancelable.yml
@@ -1,0 +1,14 @@
+rules:
+  - id: cancelable-context-not-systematically-cancelled
+    patterns:
+      - pattern: $_, $X := context.$CANCELABLE(...)
+      - pattern-not-inside: |
+          $_, $X := context.$CANCELABLE(...)
+          ...
+          defer $X()
+      - metavariable-regex:
+          metavariable: '$CANCELABLE'
+          regex: '(WithDeadline|WithTimeout)'    
+    message: it is good practice to call context cancellation function, $X(), in any case
+    languages: [go]
+    severity: WARNING


### PR DESCRIPTION
As documented by the [context package](https://pkg.go.dev/context) it is good practice to call cancellation function of cancelable contexts.
This PR adds a semgrep rule to spot cancelable contexts that are not systematically canceled.