### PR TITLE
Add non defer use to context cancelable check

### DIFF
--- a/contextCancelable.yml
+++ b/contextCancelable.yml
@@ -6,6 +6,10 @@ rules:
           $_, $X := context.$CANCELABLE(...)
           ...
           defer $X()
+      - pattern-not-inside: |
+          $_, $X := context.$CANCELABLE(...)
+          ...
+          $X()
       - metavariable-regex:
           metavariable: '$CANCELABLE'
           regex: '(WithDeadline|WithTimeout)'    


### PR DESCRIPTION
For the normal use of context cancel func like that one:
```
package main

import (
	"context"
	"time"
)

func main() {
	_, cancelFunc := context.WithTimeout(context.Background(), time.Minute)

	cancelFunc()
}
```
check is giving a false positive result:
```
❯ semgrep -f ~/s2b/code/stuff/semgrep-go .
Running 46 rules...

 main.go
     Users.odk.s2b.code.stuff.semgrep-go.cancelable-context-not-systematically-cancelled
        it is good practice to call context cancellation function, cancelFunc(), in any case


          9┆ _, cancelFunc := context.WithTimeout(context.Background(), time.Minute)

skipped: all .gitignored files
for a detailed list of skipped files, run semgrep with the --verbose flag

ran 46 rules on 1 files: 1 findings
```
This PR adds another case that covers this situation.
