### PR TITLE
Add autofix for JSON and YAML Marshaler/Unmarshaler check

### DIFF
--- a/marshaljson.yml
+++ b/marshaljson.yml
@@ -11,8 +11,9 @@ rules:
   - id: marshal-json-misspell
     pattern-either:
       - patterns:
-          - pattern-regex: (?i)func \(.+\) marshal[l]?json\(
+          - pattern-regex: (?i)func \((.+)\) marshal[l]?json\((.*)\)
           - pattern-not-regex: func \(.+\) MarshalJSON\(
+    fix: func ($1) MarshalJSON($2)
     message: |
       Misspelling of MarshalJSON.
     languages: [go]
@@ -21,8 +22,9 @@ rules:
   - id: unmarshal-json-misspell
     pattern-either:
       - patterns:
-          - pattern-regex: (?i)func \(.+\) unmarshal[l]?json\(
+          - pattern-regex: (?i)func \((.+)\) unmarshal[l]?json\((.*)\)
           - pattern-not-regex: func \(.+\) UnmarshalJSON\(
+    fix: func ($1) UnmarshalJSON($2)
     message: |
       Misspelling of UnmarshalJSON.
     languages: [go]

--- a/marshalyaml.yml
+++ b/marshalyaml.yml
@@ -2,8 +2,9 @@ rules:
   - id: marshal-yaml-misspell
     pattern-either:
       - patterns:
-          - pattern-regex: (?i)func \(.+\) marshal[l]?yaml\(
+          - pattern-regex: (?i)func \((.+)\) marshal[l]?yaml\((.*)\)
           - pattern-not-regex: func \(.+\) MarshalYAML\(
+    fix: func ($1) MarshalYAML($2)
     message: |
       Misspelling of MarshalYAML.
     languages: [go]
@@ -12,8 +13,9 @@ rules:
   - id: unmarshal-yaml-misspell
     pattern-either:
       - patterns:
-          - pattern-regex: (?i)func \(.+\) unmarshal[l]?yaml\(
+          - pattern-regex: (?i)func \((.+)\) unmarshal[l]?yaml\((.*)\)
           - pattern-not-regex: func \(.+\) UnmarshalYAML\(
+    fix: func ($1) UnmarshalYAML($2)
     message: |
       Misspelling of UnmarshalYAML.
     languages: [go]


### PR DESCRIPTION
Add a autofix that amends misspellings of:
- MarshalJSON
- UnmarshalJSON
- MarshalYAML
- UnmarshalYAML