### PR TITLE
ruleguard: suggest t.Setenv in test cases

### DIFF
--- a/ruleguard.rules.go
+++ b/ruleguard.rules.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package gorules
@@ -418,6 +419,16 @@ func badlock(m dsl.Matcher) {
 		Where(m["mu1"].Text == m["mu2"].Text).
 		At(m["mu2"]).
 		Report(`maybe defer $mu1.RUnlock() was intended?`)
+}
+
+func setenvUsedInTests(m dsl.Matcher) {
+	m.Match(
+		`os.Setenv($key, $val); defer os.Unsetenv($key)`,
+		`os.Setenv($key, $val); defer os.Setenv($key, "")`,
+	).
+		Where(m.File().Name.Matches("_test.go")).
+		Report(`should prefer t.Setenv within tests`).
+		Suggest(`t.Setenv($key, $val)`)
 }
 
 func contextTODO(m dsl.Matcher) {


### PR DESCRIPTION
Where an existing testcase has a pattern of:
```
os.Setenv("KEY", "VALUE")
defer os.Unsetenv("KEY")
```

Suggest replacement of:
```
t.Setenv("KEY")
```

As this will handle the `defer` for you and will restore the previous
value, rather than unsetting it. It will also ensure a compile time
error is raised if the test has been marked as `t.Parallel` (which would
be unsafe).