### PR TITLE
fix: Use unique ID for return-nil-err

### DIFF
--- a/nilerr.yml
+++ b/nilerr.yml
@@ -1,5 +1,5 @@
 rules:
-  - id: return-nil
+  - id: return-nil-err
     patterns:
         - pattern-either:
               - pattern: |


### PR DESCRIPTION
`nilerr.yml` uses the same rule ID as `returnnil.yml` which can cause
race conditions when both are included together.

There is some overlap in the two rules that may be worth re-evaluating
but the simplest fix to prevent these race conditions is assigning unique IDs
for each