### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To run all semgrep rules:
 $ semgrep -f path/to/semgrep-go/ .
 ```
 
-To run all semgrep rules via registry:
+To run semgrep rules via registry (please note, registry data might be out-of-date):
 ```
 $ semgrep --config=p/semgrep-go-correctness
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ To run all semgrep rules:
 $ semgrep -f path/to/semgrep-go/ .
 ```
 
+To run all semgrep rules via registry:
+```
+$ semgrep --config=p/semgrep-go-correctness
+```
+
 To run all the ruleguard rules:
 
 ```


### PR DESCRIPTION
~Is there a reason this is not documented?~

Also, is there a practical difference to `semgrep--config=https://semgrep.dev/r/dgryski.semgrep-go`, shared [here](https://github.com/dgryski/semgrep-go/issues/10#issuecomment-694395464)?

Edit: Duh, seems like the registry is not up-to-date. 59 registry vs 65 local rules. Guess would be better if we could ensure registry ruleset is always in-synch. I'm happy to give it a go, but would love to hear some ideas first.
What do you think? Is this an overkill? Am I completely off?