### PR TITLE
Update message for leaky-time-after

### DIFF
--- a/timeafter.yml
+++ b/timeafter.yml
@@ -11,6 +11,6 @@ rules:
                       }
                       ...
                   }
-    message: "Leaky use of time.After in for-select"
+    message: "Leaky use of time.After in for-select, see: https://groups.google.com/g/golang-nuts/c/cCdm0Ixwi9A/m/jMiJJScAEAAJ"
     languages: [go]
     severity: ERROR


### PR DESCRIPTION
Update the message for leaky-time-after to include a link explaining the bug-- the current description implies this is a true memory leak, when it's a bit more complicated in reality (in tight loops it can cause high memory usage, but won't leak once the loop has terminated)