### PR TITLE
chore(readeof): Improve patterns to specify data types

### DIFF
--- a/readeof.yml
+++ b/readeof.yml
@@ -2,12 +2,12 @@ rules:
   - id: read-io-eof
     patterns:
                     - pattern: |
-                        $N, $ERR := $R.Read($SLICE)
+                        $N, $ERR := $R.Read(($SLICE : []byte))
                         if $ERR != nil {
                             return ...
                         }
                     - pattern-not: |
-                        $N, $ERR := rand.Read($SLICE)
+                        $N, $ERR := rand.Read(($SLICE : []byte))
                         if $ERR != nil {
                             return ...
                         }


### PR DESCRIPTION
Reduce false-positive patterns to specify data types.
I want to pass below code that using [bigquery.Read](https://pkg.go.dev/cloud.google.com/go/bigquery#Query.Read) without error detections.

```go
q := client.Query("select name, num from t1")
iter, err := q.Read(ctx)
if err != nil {
	return err
}
```