### PR TITLE
add t.Cleanup to contextCancelable

### DIFF
--- a/contextCancelable.yml
+++ b/contextCancelable.yml
@@ -10,6 +10,9 @@ rules:
           $_, $X := context.$CANCELABLE(...)
           ...
           $X()
+      - pattern-not-inside: |
+          $_, $X := context.$CANCELABLE(...)
+          t.Cleanup($X)
       - metavariable-regex:
           metavariable: '$CANCELABLE'
           regex: '(WithDeadline|WithTimeout)'    

--- a/contextCancelable.yml
+++ b/contextCancelable.yml
@@ -12,6 +12,7 @@ rules:
           $X()
       - pattern-not-inside: |
           $_, $X := context.$CANCELABLE(...)
+          ...
           t.Cleanup($X)
       - metavariable-regex:
           metavariable: '$CANCELABLE'


### PR DESCRIPTION
I'm getting the following code in test being flagged with `cancelable-context-not-systematically-cancelled`:
```go
    test: func(t *testing.T) {
        ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
        t.Cleanup(cancel)
```
which seems a clear false positive - [test.Cleanup](https://pkg.go.dev/testing#T.Cleanup).  With the suggest change, those code snippets are not in the flagged issues.