### PR TITLE
add check for 'if x == nil && len(x) > 0'

### DIFF
--- a/badnilguard.yml
+++ b/badnilguard.yml
@@ -4,10 +4,12 @@ rules:
         - pattern-either:
               - pattern: $X == nil && <... $X.$F ...>
               - pattern: $X != nil || <... $X.$F ...>
+              - pattern: $X == nil && <... len($X) > 0 ...>
               - pattern: <... $X.$F ...> && $X != nil
               - pattern: <... $X.$F ...> || $X == nil
               - pattern: <... $X.$F ...> && $X == nil
               - pattern: <... $X.$F ...> || $X != nil
+              - pattern: <... len($X) > 0 ...> && $X == nil
     message: "Bad nil guard"
     languages: [go]
     severity: ERROR


### PR DESCRIPTION
PR adds a check for a pattern from a recent PR review - with `x` being a slice (or map), an erroneous check for `x == nil && len(x) > 0`, two contradictory conditions that cannot be true at the same time, since the length of a nil slice or map is defined to be 0:
* https://go.dev/tour/moretypes/12 "A nil slice has a length and capacity of 0 and has no underlying array."
* https://go.dev/doc/effective_go#slices "len and cap are legal when applied to the nil slice, and return `0`."