### PR TITLE
feat: add a couple of rules for go:generate

### DIFF
--- a/go-generate.yml
+++ b/go-generate.yml
@@ -1,0 +1,16 @@
+# go generate directives
+#
+# the comment must start at the beginning of the line and have no spaces between the // and the go:generate
+rules:
+  - id: go-generate-must-not-be-indented
+    message: any //go:generate comment must appear at the start of a line
+    severity: ERROR
+    languages: [go]
+    patterns:
+      - pattern-regex: ".//go:generate"
+  - id: go-generate-must-not-have-space-after-comment
+    message: the go:generate directive must have no spaces between the // and go:generate
+    severity: ERROR
+    languages: [go]
+    patterns:
+      - pattern-regex: "//\\s+go:generate"


### PR DESCRIPTION
Catch simple mistakes that can prevent (re-)generation of go generate output

For example either of these two will just cause go generate to silently skip over the commands:
```go
// go:generate example-command

type (
    //go:generate example-command
    foo interface{}
)
```